### PR TITLE
Bugfixes, NuGet updates, Best Practices

### DIFF
--- a/WebView2/WebCode/music-player.html
+++ b/WebView2/WebCode/music-player.html
@@ -92,6 +92,14 @@
         function nextTrack() {
             mediaPlaybackController.skipNext();
         }
+        function openStore() {
+            // This is just a sample store page to demonstrate protocol launching.
+            // Note that if you want to request ratings for your app, you should use the
+            // StoreContext.RequestRateAndReviewAppAsync native API instead of launching the store
+            // page directly. See:
+            // https://learn.microsoft.com/en-us/windows/uwp/monetize/request-ratings-and-reviews
+            window.location.href = "ms-windows-store://pdp/?ProductId=9MV0B5HZVK9Z";
+        }
 
         // Functions to update the text of controls to match the video state
         // ----------------------
@@ -167,6 +175,8 @@
                     <button class="MediaButton" id="ToggleMuteBtn" title="Mute" onclick="toggleMute()"></button>
                     <button class="MediaButton" id="VolumeUpBtn" title="Volume Up" onclick="addVolume(0.1)">➕</button>
                     <button class="MediaButton" id="VolumeDownBtn" title="Volume Down" onclick="addVolume(-0.1)">➖</button>
+                    <span>|</span>
+                    <button class="MediaButton" id="OpenStore" title="Open Store" onclick="openStore()">🛒</button>
                 </div>
             </div>
         </div>

--- a/WebView2/WebCode/playlistdata/video-playlist.json
+++ b/WebView2/WebCode/playlistdata/video-playlist.json
@@ -4,35 +4,35 @@
       "Title": "Sintel Trailer",
       "Subtitle": "HD Version",
       "DisplayType": "fullhd",
-      "Url": "https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
+      "Url": "https://sampleassets.z5.web.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
       "TextTrack": "subtitles/sintel_trailer_en.vtt"
     },
     {
       "Title": "Sintel Trailer",
       "Subtitle": "DolbyVision Version",
       "DisplayType": "dolbyVision4k",
-      "Url": "https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
+      "Url": "https://sampleassets.z5.web.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
       "TextTrack": "subtitles/sintel_trailer_en.vtt"
     },
     {
       "Title": "Sintel Trailer",
       "Subtitle": "HDR 4K Version",
       "DisplayType": "hdr4k",
-      "Url": "https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
+      "Url": "https://sampleassets.z5.web.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
       "TextTrack": "subtitles/sintel_trailer_en.vtt"
     },
     {
       "Title": "Sintel Trailer",
       "Subtitle": "SDR 4K Version",
       "DisplayType": "sdr4k",
-      "Url": "https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
+      "Url": "https://sampleassets.z5.web.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
       "TextTrack": "subtitles/sintel_trailer_en.vtt"
     },
     {
       "Title": "Sintel Trailer",
       "Subtitle": "50Hz Version",
       "DisplayType": "50hz",
-      "Url": "https://mediaplatstorage1.blob.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
+      "Url": "https://sampleassets.z5.web.core.windows.net/windows-universal-samples-media/sintel_trailer-480p.mp4",
       "TextTrack": "subtitles/sintel_trailer_en.vtt"
     }
   ]

--- a/WebView2/WebCode/video-player.html
+++ b/WebView2/WebCode/video-player.html
@@ -271,6 +271,14 @@
             subtitles.mode = subtitles.mode === "showing" ? "hidden" : "showing";
             updateSubtitlesText();
         }
+        function openStore() {
+            // This is just a sample store page to demonstrate protocol launching.
+            // Note that if you want to request ratings for your app, you should use the
+            // StoreContext.RequestRateAndReviewAppAsync native API instead of launching the store
+            // page directly. See:
+            // https://learn.microsoft.com/en-us/windows/uwp/monetize/request-ratings-and-reviews
+            window.location.href = "ms-windows-store://pdp/?ProductId=9MV0B5HZVK9Z";
+        }
 
         // Functions to update the text of controls to match the video state
         // ----------------------
@@ -330,7 +338,9 @@
                     <button class="MediaButton" id="ToggleMuteBtn" title="Mute" onclick="toggleMute()"></button>
                     <button class="MediaButton" id="VolumeUpBtn" title="Volume Up" onclick="addVolume(0.1)">➕</button>
                     <button class="MediaButton" id="VolumeDownBtn" title="Volume Down" onclick="addVolume(-0.1)">➖</button>
+                    <span>|</span>
                     <button class="MediaButton" id="ToggleSubtitlesBtn" title="Show Subtitles" onclick="toggleSubtitles()"></button>
+                    <button class="MediaButton" id="OpenStore" title="Open Store" onclick="openStore()">🛒</button>
                 </div>
             </div>
         </div>

--- a/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/App.cpp
+++ b/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/App.cpp
@@ -57,14 +57,14 @@ App::App()
     // something that matches the app's color scheme so it does not produce a jarring flash.
     if (_putenv("WEBVIEW2_DEFAULT_BACKGROUND_COLOR=FF101010") == -1)
     {
-        OutputDebugString(L"Unable to set WebView2 default background color.");
+        OutputDebugString(L"Unable to set WebView2 default background color.\n");
     }
 
     // By default, XAML apps are scaled up 2x on Xbox. This line disables that behavior, allowing the
     // app to use the actual resolution of the device (1920 x 1080 pixels).
     if (!ApplicationViewScaling::TrySetDisableLayoutScaling(true))
     {
-        OutputDebugString(L"Error: Failed to disable layout scaling.");
+        OutputDebugString(L"Error: Failed to disable layout scaling.\n");
     }
 }
 

--- a/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/JavaScriptMusicSample.vcxproj
+++ b/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/JavaScriptMusicSample.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -194,18 +194,18 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220531.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.h
+++ b/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.h
@@ -26,9 +26,11 @@ namespace winrt::JavaScriptMusicSample::implementation
 
         winrt::event_token navigationCompletedEventToken{};
 
+        fire_and_forget InitializeWebView();
         void OnUnloaded(IInspectable const&, Windows::UI::Xaml::RoutedEventArgs const&);
         void OnNavigationCompleted(Microsoft::UI::Xaml::Controls::WebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2NavigationCompletedEventArgs const&);
-        fire_and_forget InitializeWebView();
+        fire_and_forget OnLaunchingExternalUriScheme(winrt::Microsoft::Web::WebView2::Core::CoreWebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2LaunchingExternalUriSchemeEventArgs const&);
+		void OnWebViewProcessFailed(winrt::Microsoft::Web::WebView2::Core::CoreWebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2ProcessFailedEventArgs const&);
     };
 }
 

--- a/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/packages.config
+++ b/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.8.7" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
 </packages>

--- a/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj
+++ b/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj
@@ -116,17 +116,17 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
+++ b/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
@@ -23,4 +23,7 @@
   <ItemGroup>
     <None Include="PropertySheet.props" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+  </ItemGroup>
 </Project>

--- a/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/packages.config
+++ b/WebView2/cpp/JavaScriptMusicSample/WinRTAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/App.cpp
+++ b/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/App.cpp
@@ -43,21 +43,21 @@ App::App()
     // This is necessary because the way the WebView handles the button presses is inconsistent.
     if (_putenv("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--disable-features=HardwareMediaKeyHandling") == -1)
     {
-        OutputDebugString(L"Unable to disable hardware media key handling.");
+        OutputDebugString(L"Unable to disable hardware media key handling.\n");
 	}
 
     // The WebView's default draw color can sometimes show while a page is loading. Set it to
     // something that matches the app's color scheme so it does not produce a jarring flash.
     if (_putenv("WEBVIEW2_DEFAULT_BACKGROUND_COLOR=FF101010") == -1)
     {
-        OutputDebugString(L"Unable to set WebView2 default background color.");
+        OutputDebugString(L"Unable to set WebView2 default background color.\n");
     }
 
     // By default, XAML apps are scaled up 2x on Xbox. This line disables that behavior, allowing the
     // app to use the actual resolution of the device (1920 x 1080 pixels).
     if (!ApplicationViewScaling::TrySetDisableLayoutScaling(true))
     {
-        OutputDebugString(L"Error: Failed to disable layout scaling.");
+        OutputDebugString(L"Error: Failed to disable layout scaling.\n");
     }
 }
 

--- a/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/JavaScriptVideoSample.vcxproj
+++ b/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/JavaScriptVideoSample.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -200,18 +200,18 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.8.7\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.h
+++ b/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.h
@@ -46,6 +46,8 @@ namespace winrt::JavaScriptVideoSample::implementation
         void OnWebMessageReceived(Microsoft::UI::Xaml::Controls::WebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2WebMessageReceivedEventArgs const&);
         void OnSMTCButtonPressed(Windows::Media::SystemMediaTransportControls const&, Windows::Media::SystemMediaTransportControlsButtonPressedEventArgs const&);
         void OnDisplayModeChanged(Windows::Graphics::Display::Core::HdmiDisplayInformation const&, Windows::Foundation::IInspectable const&);
+        fire_and_forget OnLaunchingExternalUriScheme(winrt::Microsoft::Web::WebView2::Core::CoreWebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2LaunchingExternalUriSchemeEventArgs const&);
+        void OnWebViewProcessFailed(winrt::Microsoft::Web::WebView2::Core::CoreWebView2 const&, Microsoft::Web::WebView2::Core::CoreWebView2ProcessFailedEventArgs const&);
 
         void HandleJsonNotification(Windows::Data::Json::JsonObject const& json);
         void UpdatePlaybackProgress(double currentTime, double duration);

--- a/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/packages.config
+++ b/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.8.7" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
 </packages>

--- a/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj
+++ b/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj
@@ -116,17 +116,17 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
+++ b/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
@@ -23,4 +23,7 @@
   <ItemGroup>
     <None Include="PropertySheet.props" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+  </ItemGroup>
 </Project>

--- a/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/packages.config
+++ b/WebView2/cpp/JavaScriptVideoSample/WinRTAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/WebView2/cs/JavaScriptMusicSample/JavaScriptMusicSample/JavaScriptMusicSample.csproj
+++ b/WebView2/cs/JavaScriptMusicSample/JavaScriptMusicSample/JavaScriptMusicSample.csproj
@@ -111,10 +111,10 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.8.6</Version>
+      <Version>2.8.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.2478.35</Version>
+      <Version>1.0.3179.45</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj
+++ b/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj
@@ -116,17 +116,17 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
+++ b/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
@@ -23,4 +23,7 @@
   <ItemGroup>
     <None Include="PropertySheet.props" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+  </ItemGroup>
 </Project>

--- a/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/packages.config
+++ b/WebView2/cs/JavaScriptMusicSample/WinRTAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/JavaScriptVideoSample.csproj
+++ b/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/JavaScriptVideoSample.csproj
@@ -102,10 +102,10 @@
       <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.8.6</Version>
+      <Version>2.8.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.2478.35</Version>
+      <Version>1.0.3179.45</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.xaml.cs
+++ b/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.xaml.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.System.Profile;
+using Windows.System;
 
 namespace JavaScriptVideoSample
 {
@@ -113,6 +114,12 @@ namespace JavaScriptVideoSample
                 coreWV2.Settings.IsStatusBarEnabled = false;
                 coreWV2.Settings.HiddenPdfToolbarItems = CoreWebView2PdfToolbarItems.None;
 
+                // This turns off SmartScreen, which can have some performance impact. This is ONLY safe
+                // to do if you are certain that your app will only ever visit trusted pages that you
+                // control. If there is a chance your app could end up browsing the open web, you should
+                // delete this line.
+                coreWV2.Settings.IsReputationCheckingRequired = false;
+
                 // This prevents the user from opening the DevTools with F12, it does not prevent you from
                 // attaching the Edge Dev Tools yourself.
                 coreWV2.Settings.AreDevToolsEnabled = false; 
@@ -161,6 +168,8 @@ namespace JavaScriptVideoSample
                 webView.WebMessageReceived += OnWebMessageReceived;
                 webView.NavigationStarting += OnNavigationStarting;
                 webView.NavigationCompleted += OnNavigationCompleted;
+                coreWV2.ProcessFailed += OnWebViewProcessFailed;
+                coreWV2.LaunchingExternalUriScheme += OnLaunchingExternalUriScheme;
 
                 // Pass the device type as a query parameter. This data could be passed in other ways as
                 // well, such as by setting the UserAgent string in the WebView's CoreWebView2Settings,
@@ -419,6 +428,40 @@ namespace JavaScriptVideoSample
                 Debug.WriteLine("Display mode has changed.");
                 await webView.ExecuteScriptAsync("updateDisplayModeAsync();");
             });
+        }
+
+        /// <summary>
+        /// Called whenever the WebView attempts to launch another app through a URI scheme.
+        /// The confirmation dialog cannot be navigated by the Xbox controller, so we reroute it to
+        /// use the native API instead.
+        /// </summary>
+        /// <param name="args">The details of the protocol launch.</param>
+        private async void OnLaunchingExternalUriScheme(CoreWebView2 sender, CoreWebView2LaunchingExternalUriSchemeEventArgs args)
+        {
+            // Cancel the default behavior of the WebView because we do not want it to show a dialog
+            args.Cancel = true;
+
+            // Launch the URI using the native API instead
+            await Launcher.LaunchUriAsync(new Uri(args.Uri));
+        }
+
+        /// <summary>
+        /// Called when one of the WebView processes fails. This implementation merely prints out the
+        /// details of the process failure to the console. If you have a telemetry system, you could
+        /// also capture this information for further analysis.
+        /// </summary>
+        /// <param name="args">Details about the failure.</param>
+        private void OnWebViewProcessFailed(CoreWebView2 sender, CoreWebView2ProcessFailedEventArgs args)
+        {
+            Debug.WriteLine("WebView Process failed:");
+            Debug.WriteLine($"* Exit Code: {args.ExitCode}");
+            Debug.WriteLine($"* Failure Source Module Path: {args.FailureSourceModulePath}");
+            Debug.WriteLine($"* Process Description: {args.ProcessDescription}");
+            Debug.WriteLine($"* Process Failed Kind: {args.ProcessFailedKind}");
+            Debug.WriteLine($"* Process Failed Reason: {args.Reason}");
+
+            // Note that there is additional frame information that can be found under
+            // FrameInfosForFailedProcess(), if relevant for your use case.
         }
     }
 }

--- a/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj
+++ b/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj
@@ -116,17 +116,17 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
-    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2478.35\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.3179.45\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
+++ b/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/WinRTAdapter.vcxproj.filters
@@ -23,7 +23,4 @@
   <ItemGroup>
     <None Include="PropertySheet.props" />
   </ItemGroup>
-  <ItemGroup>
-    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
-  </ItemGroup>
 </Project>

--- a/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/packages.config
+++ b/WebView2/cs/JavaScriptVideoSample/WinRTAdapter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.2478.35" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3179.45" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
**Changelist:**
1. Updated to the latest NuGet packages
1. Added a button to launch the Microsoft store, demonstrating how to correctly kick off protocol launches
1. Disabled SmartScreen by default (see code comment, this is appropriate only for tailored single-app experiences)
1. Added a ProcessFailed handler
1. Changed to new sample server for video content
1. Fixed some C++ debug statements that were missing newlines