### PR TITLE
Minor bugfixes and changes for clarity

### DIFF
--- a/WebView2/WebCode/uwpdisplaymode.js
+++ b/WebView2/WebCode/uwpdisplaymode.js
@@ -173,14 +173,20 @@ var uwpDisplayMode = (function (Windows, WindowsProxies) {
     // https://learn.microsoft.com/en-us/uwp/api/windows.media.protection.protectioncapabilities.istypesupported
     public.isTypeSupportedAsync = async function (type) {
         try {
+            // This string checks for PlayReady SL3000 (hardware) support. Your app must
+            // specify the hevcPlayback capability in its appxmanifest file to use SL3000.
+            // If you only need SL2000, use "com.microsoft.playready.recommendation" instead.
+            // For more information see:
+            // https://learn.microsoft.com/en-us/playready/overview/key-system-strings
+            let playReadyVersion = "com.microsoft.playready.recommendation.3000";
             let protCap = Windows.Media.Protection.ProtectionCapabilities();
-            let result = protCap.isTypeSupported(type, "com.microsoft.playready.hardware");
+            let result = protCap.isTypeSupported(type, playReadyVersion);
 
             // Continue checking until we get a non-maybe result. This API will not return
             // "maybe" for more than 10 seconds.
             while (result == Windows.Media.Protection.ProtectionCapabilityResult.maybe) {
                 await new Promise(r => setTimeout(r, 100));
-                result = protCap.isTypeSupported(type, "com.microsoft.playready.hardware");
+                result = protCap.isTypeSupported(type, playReadyVersion);
             }
 
             return (result != Windows.Media.Protection.ProtectionCapabilityResult.notSupported);

--- a/WebView2/WebCode/video-player.html
+++ b/WebView2/WebCode/video-player.html
@@ -43,6 +43,9 @@
             // Set a blank poster image so the default poster doesn't show
             mediaElement.poster = "poster.png";
 
+            // Don't show streaming button
+            mediaElement.disableRemotePlayback = true;
+
             // Update the UI to show the first video
             await updateVideoAsync();
 

--- a/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.cpp
+++ b/WebView2/cpp/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.cpp
@@ -77,7 +77,6 @@ namespace winrt::JavaScriptMusicSample::implementation
             settings.IsGeneralAutofillEnabled(false);
             settings.IsPasswordAutosaveEnabled(false);
             settings.IsStatusBarEnabled(false);
-            settings.HiddenPdfToolbarItems(CoreWebView2PdfToolbarItems::None);
 
             // This turns off SmartScreen, which can have some performance impact. This is ONLY safe
             // to do if you are certain that your app will only ever visit trusted pages that you
@@ -190,7 +189,6 @@ namespace winrt::JavaScriptMusicSample::implementation
         std::wostringstream strStream{};
         strStream << L"WebView Process failed:\n";
         strStream << L"* Exit Code: " << args.ExitCode() << std::endl;
-        strStream << L"* Failure Source Module Path: " << args.FailureSourceModulePath().c_str() << std::endl;
         strStream << L"* Process Description: " << args.ProcessDescription().c_str() << std::endl;
 
         // Convert the process failed kind to a string

--- a/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.cpp
+++ b/WebView2/cpp/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.cpp
@@ -91,7 +91,6 @@ namespace winrt::JavaScriptVideoSample::implementation
             settings.IsGeneralAutofillEnabled(false);
             settings.IsPasswordAutosaveEnabled(false);
             settings.IsStatusBarEnabled(false);
-            settings.HiddenPdfToolbarItems(CoreWebView2PdfToolbarItems::None);
 
             // This turns off SmartScreen, which can have some performance impact. This is ONLY safe
             // to do if you are certain that your app will only ever visit trusted pages that you
@@ -455,7 +454,6 @@ namespace winrt::JavaScriptVideoSample::implementation
         std::wostringstream strStream{};
         strStream << L"WebView Process failed:\n";
         strStream << L"* Exit Code: " << args.ExitCode() << std::endl;
-        strStream << L"* Failure Source Module Path: " << args.FailureSourceModulePath().c_str() << std::endl;
         strStream << L"* Process Description: " << args.ProcessDescription().c_str() << std::endl;
 
         // Convert the process failed kind to a string

--- a/WebView2/cs/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.xaml.cs
+++ b/WebView2/cs/JavaScriptMusicSample/JavaScriptMusicSample/MainPage.xaml.cs
@@ -83,7 +83,6 @@ namespace JavaScriptMusicSample
                 coreWV2.Settings.IsGeneralAutofillEnabled = false;
                 coreWV2.Settings.IsPasswordAutosaveEnabled = false;
                 coreWV2.Settings.IsStatusBarEnabled = false;
-                coreWV2.Settings.HiddenPdfToolbarItems = CoreWebView2PdfToolbarItems.None;
 
                 // This turns off SmartScreen, which can have some performance impact. This is ONLY safe
                 // to do if you are certain that your app will only ever visit trusted pages that you
@@ -194,7 +193,6 @@ namespace JavaScriptMusicSample
         {
             Debug.WriteLine("WebView Process failed:");
             Debug.WriteLine($"* Exit Code: {args.ExitCode}");
-            Debug.WriteLine($"* Failure Source Module Path: {args.FailureSourceModulePath}");
             Debug.WriteLine($"* Process Description: {args.ProcessDescription}");
             Debug.WriteLine($"* Process Failed Kind: {args.ProcessFailedKind}");
             Debug.WriteLine($"* Process Failed Reason: {args.Reason}");

--- a/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.xaml.cs
+++ b/WebView2/cs/JavaScriptVideoSample/JavaScriptVideoSample/MainPage.xaml.cs
@@ -112,7 +112,6 @@ namespace JavaScriptVideoSample
                 coreWV2.Settings.IsGeneralAutofillEnabled = false;
                 coreWV2.Settings.IsPasswordAutosaveEnabled = false;
                 coreWV2.Settings.IsStatusBarEnabled = false;
-                coreWV2.Settings.HiddenPdfToolbarItems = CoreWebView2PdfToolbarItems.None;
 
                 // This turns off SmartScreen, which can have some performance impact. This is ONLY safe
                 // to do if you are certain that your app will only ever visit trusted pages that you
@@ -455,7 +454,6 @@ namespace JavaScriptVideoSample
         {
             Debug.WriteLine("WebView Process failed:");
             Debug.WriteLine($"* Exit Code: {args.ExitCode}");
-            Debug.WriteLine($"* Failure Source Module Path: {args.FailureSourceModulePath}");
             Debug.WriteLine($"* Process Description: {args.ProcessDescription}");
             Debug.WriteLine($"* Process Failed Kind: {args.ProcessFailedKind}");
             Debug.WriteLine($"* Process Failed Reason: {args.Reason}");


### PR DESCRIPTION
* Removed the line that sets `HiddenPdfToolbarItems`.
* Changed the playready version string to `com.microsoft.playready.recommendation.3000`.
* Explicitly set `disableRemotePlayback` on the `<video>` element.
* Removed call to `CoreWebView2ProcessFailedEventArgs.FailureSourceModulePath`.